### PR TITLE
Support out-of-order interpolation

### DIFF
--- a/lagrange/lagrange.py
+++ b/lagrange/lagrange.py
@@ -98,6 +98,10 @@ def interpolate(
     >>> lagrange({5: 64, 2: 25, 3: 36}, degree=2, prime=65537)
     9
 
+    Trivial interpolation is allowed as well.
+    >>> lagrange([12345], degree=0, prime=65537)
+    12345
+
     At least one point must be supplied.
 
     >>> interpolate([], 17)
@@ -203,7 +207,7 @@ sequences of integers
             # Extrapolate given that y=1 if x=`x_value` and y=0 for other known x in domain.
             div((0 - known_x), (x_value - known_x))
             for known_x in domain if known_x is not x_value
-        )))
+        ), 1))
         for x_value in domain
     ) % prime
 

--- a/lagrange/lagrange.py
+++ b/lagrange/lagrange.py
@@ -3,7 +3,7 @@ Pure-Python implementation of Lagrange interpolation over finite fields.
 """
 from __future__ import annotations
 from functools import reduce
-from typing import Union
+from typing import Union, Optional
 from collections.abc import Iterable, Sequence
 import doctest
 
@@ -14,7 +14,8 @@ def _inv(a, prime):
     return pow(a, prime - 2, prime)
 
 def interpolate(
-        points: Union[dict, Sequence[int], Iterable[Sequence[int]]], prime: int, degree=None
+        points: Union[dict, Sequence[int], Iterable[Sequence[int]]], prime: int,
+        degree: Optional[int] = None
     ) -> int:
     # pylint: disable=R0912 # Accommodate large number of branches for type checking.
     """


### PR DESCRIPTION
Values, such as those at $x=5$, $x=2$, $x=3$ in the degree-2 polynomial $y = (x+3)^2$, can be easily interpolated (for the y-intercept) as shown below.
```python
>>> lagrange({5: 64, 2: 25, 3: 36}, prime=101)
9
```

There is also an optional `degree=` parameter which is useful for when the list of values passed to `lagrange` has an unknown length beyond the desired degree.  The documentation has more examples.


(Resolves lapets/lagrange#1)